### PR TITLE
Fix typo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,9 @@ Clone a copy of the main jQuery git repo by running:
 git clone git://github.com/jquery/jquery.git
 ```
 
-Enter the jquery directory and run the build script:
+Enter the src directory and run the build script:
 ```bash
-cd jquery && npm run build
+cd src && npm run build
 ```
 The built version of jQuery will be put in the `dist/` subdirectory, along with the minified copy and associated map file.
 


### PR DESCRIPTION
The directory to build in is called "src" not "jquery".
